### PR TITLE
[#31] refactor:파일 충돌로 prettier적용이 되지 않는 것 확인 수정

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -9,5 +9,7 @@
   "endOfLine": "auto",
   "bracketSpacing": true,
   "jsxSingleQuote": false,
-  "proseWrap": "preserve"
+  "proseWrap": "preserve",
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["clsx"]
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,0 @@
-// prettier.config.js
-
-/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
-export default {
-  plugins: ["prettier-plugin-tailwindcss"],
-  tailwindFunctions: ["clsx"],
-};


### PR DESCRIPTION


closes #(31) 


## 변경 사항 요약
작업했던 브랜치에서 적용되는것 확인 후 pr했으나,  pull 하고 적용 하였을때
파일 충돌로 prettier적용이 되지 않는 것 확인하여, prettier.config.js 삭제하고  .prettierrc.json로 의존성 이동했습니다.
모든 브랜치에서 적용 되는 것 확인하였습니다. 

### 스크린샷
적용전
<img width="926" height="47" alt="1" src="https://github.com/user-attachments/assets/65031f34-5715-4f4b-aa5f-4126be48338f" />
<img width="1059" height="79" alt="2" src="https://github.com/user-attachments/assets/55ac733d-c480-4885-8116-d9bb75db6d55" />
적용후
<img width="944" height="43" alt="3" src="https://github.com/user-attachments/assets/732707fa-2221-43ab-a3a5-075bbc5e67d6" />
<img width="1034" height="80" alt="4" src="https://github.com/user-attachments/assets/17e83bcb-e85c-40fb-bc50-2ef45386ccf7" />

### PR 올리기 전 체크리스트 (필수로 체크)

- [ ] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [ ] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항

npm install 해주세요.
