### PR TITLE
bug: 로그인 안했을 때 헤더 때문에 페이지 에러 해결

### DIFF
--- a/src/components/Header/UserHeader/index.tsx
+++ b/src/components/Header/UserHeader/index.tsx
@@ -109,7 +109,7 @@ const UserHeader = () => {
 
   const { data: userInfo } = useGetMyInfoQuery(userId);
 
-  const userType: UserType = userInfo?.item.type ?? "employee";
+  const userType: UserType = userInfo?.item?.type ?? "employee";
   const isLogined = Boolean(userId);
 
   return (


### PR DESCRIPTION
## 이슈번호

close #

## 변경 사항 요약

- UserHeader에 문제가 있는 것 같아서 로그인하지 않으면 joblist, shopInfo 같은 헤더를 사용하는 모든 페이지들이 렌더링 되지 않는 에러가 있었습니다

<img width="2028" height="1194" alt="image" src="https://github.com/user-attachments/assets/89bb0007-70df-4927-a4e0-61ea66e8924c" />
