### PR TITLE
[#170] 공고상세 페이지 최근에 본 공고 로직 수정

### DIFF
--- a/src/pages/jobinfo/_components/jobdetail.tsx
+++ b/src/pages/jobinfo/_components/jobdetail.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from "react";
-import { SeoulAddress } from "@/types/global";
 import IcCheck from "@/assets/svgs/ic_check.svg";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import Button from "@/components/Button";
@@ -110,18 +109,29 @@ const JobDetail = ({ shopId, noticeId, jobData, isPending }: JobDetailProps) => 
       return;
     }
     addRecentViewedJob({
-      id: noticeId,
-      hourlyPay: jobData?.item.hourlyPay as number,
-      startsAt: jobData?.item.startsAt as string,
-      workhour: jobData?.item.workhour as number,
-      closed: jobData?.item.closed as boolean,
-      name: jobData?.item.shop.item.name as string,
-      imageUrl: jobData?.item.shop.item.imageUrl as string,
-      address: jobData?.item.shop.item.address1 as SeoulAddress,
-      originalHourlyPay: jobData?.item.shop.item.originalHourlyPay as number,
+      noticeId,
       shopId,
     });
   }, [jobData]);
+
+  const handleCancelClick = () => {
+    putShopApplication(
+      {
+        shopId,
+        noticeId,
+        applicationId,
+        data: {
+          status: "canceled",
+        },
+      },
+      {
+        onSuccess: () => {
+          setIsApply(false);
+          setIsOpen(!isOpen);
+        },
+      },
+    );
+  };
 
   const getFooters = useCallback((): ButtonSetting[] => {
     if (!isProfile && userId) {
@@ -202,25 +212,6 @@ const JobDetail = ({ shopId, noticeId, jobData, isPending }: JobDetailProps) => 
         },
         onError: (err) => {
           console.error("신청 에러:", err);
-        },
-      },
-    );
-  };
-
-  const handleCancelClick = () => {
-    putShopApplication(
-      {
-        shopId,
-        noticeId,
-        applicationId,
-        data: {
-          status: "canceled",
-        },
-      },
-      {
-        onSuccess: () => {
-          setIsApply(false);
-          setIsOpen(!isOpen);
         },
       },
     );

--- a/src/pages/jobinfo/_components/recentlist.tsx
+++ b/src/pages/jobinfo/_components/recentlist.tsx
@@ -1,36 +1,59 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import Post from "@/components/Post";
-import { RecentJob, getRecentViewedJobs } from "@/utils/recentList";
+import { SeoulAddress } from "@/types/global";
+import { RecentJobId, getRecentViewedJobs } from "@/utils/recentList";
+import { getShopNoticeDetail } from "@/hooks/api/notice/useGetShopNoticeDetailQuery";
+import { useQueries } from "@tanstack/react-query";
 
 const RecentList = () => {
-  const [jobs, setJobs] = useState<RecentJob[]>([]);
+  const [jobIds, setJobIds] = useState<RecentJobId[]>([]);
 
   useEffect(() => {
-    setJobs(getRecentViewedJobs());
+    setJobIds(getRecentViewedJobs());
   }, []);
+
+  const jobQueries = useQueries({
+    queries: jobIds.map((id) => ({
+      queryKey: ["getShopNoticeDetail", id.shopId, id.noticeId],
+      queryFn: () =>
+        getShopNoticeDetail({
+          shopId: id.shopId,
+          noticeId: id.noticeId,
+        }),
+      enabled: !!id.shopId && !!id.noticeId,
+    })),
+  });
+
+  const jobs = jobQueries
+    .map((q) => q.data?.item)
+    .filter(Boolean)
+    .slice(0, 6);
 
   return (
     <div className="pb-80 pt-40 tablet:pt-60">
       <h2 className="mb-32 text-20 font-bold tablet:text-28">최근에 본 공고</h2>
-      <div className="grid grid-cols-2 gap-12 desktop:grid-cols-3">
-        {jobs.map((job) => (
-          <Link href={`/jobinfo/${job.shopId}/${job.id}`} key={job.id}>
-            <Post
-              name={job.name}
-              hourlyPay={job.hourlyPay}
-              startsAt={job.startsAt}
-              workhour={job.workhour}
-              closed={job.closed}
-              imageUrl={job.imageUrl}
-              address={job.address}
-              originalHourlyPay={job.originalHourlyPay}
-              key={job.id}
-              id={`${job.shopId}/${job.id}`}
-            />
-          </Link>
-        ))}
-      </div>
+      {jobs.length === 0 ? (
+        <div className="min-h-100 text-center text-20 font-bold">최근 본 공고가 없습니다.</div>
+      ) : (
+        <div className="grid grid-cols-2 gap-12 desktop:grid-cols-3">
+          {jobs.map((job) => (
+            <Link href={`/jobinfo/${job?.shop.item.id}/${job?.id}`} key={job?.id}>
+              <Post
+                name={job?.shop.item.name as string}
+                hourlyPay={job?.hourlyPay as number}
+                startsAt={job?.startsAt as string}
+                workhour={job?.workhour as number}
+                closed={job?.closed as boolean}
+                imageUrl={job?.shop.item.imageUrl as string}
+                address={job?.shop.item.address1 as SeoulAddress}
+                originalHourlyPay={job?.shop.item.originalHourlyPay as number}
+                id={job?.id as string}
+              />
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/utils/recentList.ts
+++ b/src/utils/recentList.ts
@@ -1,19 +1,13 @@
-import { NoticeItem, SeoulAddress } from "@/types/global";
-
 const STORAGE_KEY = "recentViewedJobs";
 const MAX_ITEMS = 6;
 
-export interface RecentJob extends Omit<NoticeItem, "description"> {
-  name: string;
-  imageUrl: string;
-  address: SeoulAddress;
-  originalHourlyPay: number;
-  className?: string;
+export interface RecentJobId {
+  noticeId: string;
+  shopId: string;
   viewedAt?: Date;
-  shopId?: string;
 }
 
-export function getRecentViewedJobs(): RecentJob[] {
+export function getRecentViewedJobs(): RecentJobId[] {
   if (typeof window === "undefined") {
     return [];
   }
@@ -21,13 +15,13 @@ export function getRecentViewedJobs(): RecentJob[] {
   return data ? JSON.parse(data) : [];
 }
 
-export function addRecentViewedJob(job: Omit<RecentJob, "viewedAt">) {
+export function addRecentViewedJob(job: Omit<RecentJobId, "viewedAt">) {
   if (typeof window === "undefined") {
     return;
   }
 
   const existing = getRecentViewedJobs();
-  const filtered = existing.filter((p) => p.id !== job.id);
+  const filtered = existing.filter((j) => j.noticeId !== job.noticeId);
   const updated = [{ ...job, viewedAt: Date.now() }, ...filtered].slice(0, MAX_ITEMS);
 
   localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));


### PR DESCRIPTION
## 이슈번호

close #170 

## 변경 사항 요약
최근에 본 공고 localstorage에 키값만 저장하고
해당 키 값으로 화면에서 api 호출하여 보여지도록 수정했습니다.

### 추가된 기능
- utils/recentList 도 수정되었습니다.
- src/pages/jobinfo/_components/jobdetail.tsx 의 handleCancelClick 의 순서도 변경되었습니다.

### 스크린샷

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항
신청/취소 버튼 로직은 좀 더 고민 후 수정하도록 하겠습니다.
