### PR TITLE
[#186] 공고 신청시 버튼 상태값 유지 되도록 수정

### DIFF
--- a/src/hooks/api/application/usePostShopApplicationQuery.ts
+++ b/src/hooks/api/application/usePostShopApplicationQuery.ts
@@ -33,14 +33,21 @@ const postShopApplication = async ({
   return response.data;
 };
 
-export const usePostShopApplicationQuery = () => {
+export const usePostShopApplicationQuery = (options?: {
+  onMutate?: () => void;
+  onSuccess?: (data: PostShopApplicationResponse) => void;
+  onError?: (error: unknown) => void;
+}) => {
   return useMutation({
     mutationFn: postShopApplication,
+    onMutate: options?.onMutate,
     onSuccess: (res) => {
       console.log(res);
+      options?.onSuccess?.(res);
     },
     onError: (err) => {
-      console.log(err);
+      console.error(err);
+      options?.onError?.(err);
     },
   });
 };

--- a/src/hooks/api/application/usePutShopApplicationQuery.ts
+++ b/src/hooks/api/application/usePutShopApplicationQuery.ts
@@ -42,14 +42,21 @@ const putShopApplication = async ({
   return response.data;
 };
 
-export const usePutShopApplicationQuery = () => {
+export const usePutShopApplicationQuery = (options?: {
+  onMutate?: () => void;
+  onSuccess?: (data: PutShopApplicationResponse) => void;
+  onError?: (error: unknown) => void;
+}) => {
   return useMutation({
     mutationFn: putShopApplication,
+    onMutate: options?.onMutate,
     onSuccess: (res) => {
       console.log(res);
+      options?.onSuccess?.(res);
     },
     onError: (err) => {
-      console.log(err);
+      console.error(err);
+      options?.onError?.(err);
     },
   });
 };


### PR DESCRIPTION
## 이슈번호

close #186 

## 변경 사항 요약
공고 상세에서 신청하기 | 취소하기 버튼 클릭시 해당 상태값이 유지되도록 수정했습니다.
모달창에서 신청 취소를 선택하면 모달창이 바로 닫히도록 수정했습니다.

### 추가된 기능
- hooks에 onMutate 옵션을 추가할 수 있게 변경했습니다.

### 스크린샷

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항

