### PR TITLE
[#197] 공고상세 페이지 수정

### DIFF
--- a/src/components/Skeleton/SkeletonBox.tsx
+++ b/src/components/Skeleton/SkeletonBox.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/utils";
+
+export const SkeletonBox = ({ className = "" }) => {
+  return (
+    <div
+      className={cn(
+        "flex-0 aspect-square w-full rounded-12",
+        "bg-gradient-to-r from-gray-10 via-gray-30 to-gray-10",
+        "bg-[length:400%_100%]",
+        "animate-skeleton-shimmer",
+        className,
+      )}
+    ></div>
+  );
+};

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/utils";
+import { SkeletonBox } from "./SkeletonBox";
+
+interface SkeletonProps {
+  count: number;
+  className?: string;
+  boxClassName?: string;
+}
+
+const SkeletonUI = ({ count, className = "", boxClassName = "" }: SkeletonProps) => {
+  return (
+    <div className={cn("flex w-full flex-row flex-wrap gap-4", className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonBox key={i} className={boxClassName} />
+      ))}
+    </div>
+  );
+};
+
+export default SkeletonUI;

--- a/src/pages/jobinfo/[shopid]/[noticeid]/index.tsx
+++ b/src/pages/jobinfo/[shopid]/[noticeid]/index.tsx
@@ -37,8 +37,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 const JobInfo = ({ shopId, noticeId }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { data: jobData, isPending } = useGetShopNoticeDetailQuery({ shopId, noticeId });
   return (
-    <div className="bg-gray-5 pt-40 desktop:pt-60">
-      <div className="mx-auto min-w-375 max-w-1080 px-12 tablet:w-full tablet:px-32 desktop:w-1080">
+    <div className="bg-gray-5">
+      <div className="mx-auto flex max-w-375 flex-col tablet:max-w-680 desktop:max-w-964">
         <JobDetail shopId={shopId} noticeId={noticeId} jobData={jobData} isPending={isPending} />
         <RecentList />
       </div>

--- a/src/pages/jobinfo/_components/jobdetail.tsx
+++ b/src/pages/jobinfo/_components/jobdetail.tsx
@@ -16,6 +16,7 @@ import {
   GetShopNoticeDetailRequest,
   GetShopNoticeDetailResponse,
 } from "@/hooks/api/notice/useGetShopNoticeDetailQuery";
+import SkeletonUI from "@/components/Skeleton";
 
 interface ButtonSetting {
   buttonText: string;
@@ -164,7 +165,21 @@ const JobDetail = ({ shopId, noticeId, jobData, isPending }: JobDetailProps) => 
   }, [userId, isProfile, applicationId]);
 
   if (!shopId || !noticeId || isPending || !jobData) {
-    return <LoadingSpinner />;
+    return (
+      <div className="py-40 tablet:py-60">
+        <div>
+          <SkeletonUI count={1} boxClassName="w-[calc((100%)/3)] h-66" className="h-66" />
+        </div>
+        <div className="my-12 rounded-12 border border-gray-20 p-20 tablet:p-24 desktop:my-24">
+          <SkeletonUI
+            count={1}
+            boxClassName="w-full tablet:h-645 desktop:h-308"
+            className="tablet:h-645 desktop:h-308"
+          />
+        </div>
+        <SkeletonUI count={1} boxClassName="w-full rounded-12 h-124" className="h-124" />
+      </div>
+    );
   }
 
   const notice = jobData?.item;

--- a/src/pages/jobinfo/_components/jobdetail.tsx
+++ b/src/pages/jobinfo/_components/jobdetail.tsx
@@ -191,20 +191,28 @@ const JobDetail = ({ shopId, noticeId, jobData, isPending }: JobDetailProps) => 
   const isPassed = isStartTimePassed(notice.startsAt) || jobData.item.closed;
 
   return (
-    <>
+    <div className="py-40 tablet:py-60">
       <div>
         <p className="text-16 font-bold text-primary">{shop.category}</p>
         <h2 className="text-28 font-bold text-black">{shop.name}</h2>
       </div>
-      <div className="align-center my-12 flex h-480 flex-col justify-center justify-around gap-10 rounded-12 border border-gray-20 p-20 desktop:my-24 desktop:flex-row desktop:justify-between desktop:p-24">
-        <CardImageBox imageUrl={shop.imageUrl} name={shop.name} closed={false} startsAt={notice.startsAt} />
-        <div className="flex w-full flex-col justify-between desktop:w-364">
-          <div className="mb-40 flex flex-col gap-10 desktop:mb-60">
-            <p className="text-16 font-bold text-primary">시급</p>
-            <CardPay hourlyPay={notice.hourlyPay} originalHourlyPay={shop.originalHourlyPay} closed={notice.closed} />
-            <CardTime startsAt={notice.startsAt} workhour={notice.workhour} />
-            <CardAddress address={shop.address1} />
-            <CardDescription description={shop.description} />
+      <div className="my-12 flex flex-col justify-center rounded-12 border border-gray-20 bg-white p-20 tablet:p-24 desktop:my-24 desktop:flex-row desktop:justify-between desktop:gap-x-31">
+        <CardImageBox
+          imageUrl={shop.imageUrl}
+          name={shop.name}
+          closed={false}
+          startsAt={notice.startsAt}
+          className="desktop:h-308"
+        />
+        <div className="flex flex-col justify-between desktop:w-346">
+          <div className="mb-40 desktop:mb-60">
+            <p className="pb-4 pt-16 text-16 font-bold text-primary">시급</p>
+            <div className="flex flex-col gap-y-8 tablet:gap-y-12">
+              <CardPay hourlyPay={notice.hourlyPay} originalHourlyPay={shop.originalHourlyPay} closed={notice.closed} />
+              <CardTime startsAt={notice.startsAt} workhour={notice.workhour} />
+              <CardAddress address={shop.address1} />
+              <CardDescription description={shop.description} />
+            </div>
           </div>
           {userId && isApply ? (
             <Button
@@ -243,7 +251,7 @@ const JobDetail = ({ shopId, noticeId, jobData, isPending }: JobDetailProps) => 
       />
       {isApplySuccess && <ToastContainer label="신청이 완료 되었습니다" error={false} />}
       {isCancelSuccess && <ToastContainer label="신청이 취소 되었습니다" error={false} />}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/jobinfo/_components/recentlist.tsx
+++ b/src/pages/jobinfo/_components/recentlist.tsx
@@ -31,12 +31,12 @@ const RecentList = () => {
     .slice(0, 6);
 
   return (
-    <div className="pb-80 pt-40 tablet:pt-60">
+    <div className="py-40 tablet:py-60">
       <h2 className="mb-32 text-20 font-bold tablet:text-28">최근에 본 공고</h2>
       {jobs.length === 0 ? (
         <div className="min-h-100 text-center text-20 font-bold">최근 본 공고가 없습니다.</div>
       ) : (
-        <div className="grid grid-cols-2 gap-12 desktop:grid-cols-3">
+        <div className="grid grid-cols-2 gap-8 desktop:grid-cols-3 desktop:gap-14">
           {jobs.map((job) => (
             <Link href={`/jobinfo/${job?.shop.item.id}/${job?.id}`} key={job?.id}>
               <Post

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,16 @@ const config: Config = {
           20: "var(--green-20)",
         },
       },
+      keyframes: {
+        "skeleton-shimmer": {
+          "0%": { backgroundPosition: "-400% 0" },
+          "100%": { backgroundPosition: "400% 0" },
+        },
+      },
+      animation: {
+        "skeleton-shimmer": "skeleton-shimmer 15s linear infinite",
+        "loading-spinner": "loading-spinner 3s linear infinite alternate",
+      },
       screens: {
         mobile: "375px",
         tablet: "744px",


### PR DESCRIPTION
## 이슈번호

close #197 

## 변경 사항 요약
공고 상세 페이지의 스타일과 반응형 스타일을 수정했습니다.
스켈레톤 UI를 추가했고 반영했습니다.

### 추가된 기능
- 스켈레톤 UI 추가

### 스크린샷
<img width="1512" height="820" alt="스크린샷 2025-10-20 오전 4 49 36" src="https://github.com/user-attachments/assets/478edb0f-43f9-49c0-8986-fe242d39ffaf" />


### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항
스타일을 전체적으로 수정하는게 공수가 너무 많이들어서 다른분들이 만든 카드 섹션 UI를 참고하여 제 페이지를 수정했습니다.

공고 상세 페이지 기준 상단 카드 영역에만 스켈레톤 UI가 적용되어 있습니다.
반응형에 맞춰서 스켈레톤영역의 높이가 자동으로 바뀌는 것은 못찾았습니다.

아래의 예시 코드가 다른부분 적용에 도움이 되시면 좋겠습니다.
```
<SkeletonUI count={5} boxClassName="w-[calc((100%-1rem)/2)] tablet:w-[calc((100%-(1rem*2))/3)]" />
```