### PR TITLE
[#205] refactor/SelectBox 열고 닫는 상태 부모로 이전

### DIFF
--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -13,15 +13,26 @@ const style: STYLES = {
 };
 
 interface SelectProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   options: Option[];
   placeholder?: string;
   className?: string;
   onChange?: (option: Option) => void;
   dropdownClassname?: string;
+  onClick?: () => void;
 }
 
-const SelectBox = ({ options, placeholder = "선택", className, onChange, dropdownClassname }: SelectProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+const SelectBox = ({
+  isOpen,
+  setIsOpen,
+  options,
+  placeholder = "선택",
+  className,
+  onChange,
+  dropdownClassname,
+  onClick,
+}: SelectProps) => {
   const [selectedLabel, setSelectedLabel] = useState(placeholder);
 
   useEffect(() => {
@@ -31,7 +42,6 @@ const SelectBox = ({ options, placeholder = "선택", className, onChange, dropd
   }, [placeholder]);
 
   const handleSelect = useSelectHandler({ setSelectedLabel, setIsOpen, onChange });
-
   return (
     <div className={cn("relative w-full")}>
       <div
@@ -41,7 +51,10 @@ const SelectBox = ({ options, placeholder = "선택", className, onChange, dropd
           style.fontSelect,
           className,
         )}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          onClick?.();
+          setIsOpen(!isOpen);
+        }}
         aria-label="셀렉트 박스"
       >
         <span className={cn(placeholder === "선택" ? "text-gray-40" : "text-black")}>{selectedLabel}</span>

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -8,7 +8,7 @@ import SelectOptions from "./SelectOptions";
 type STYLES = { boxSelect: string; fontSelect: string };
 
 const style: STYLES = {
-  boxSelect: "bg-white rounded-md cursor-pointer border border-gray-40",
+  boxSelect: "bg-white rounded-md cursor-pointer border border-gray-30",
   fontSelect: "font-normal text-base text-gray-40",
 };
 

--- a/src/pages/joblist/_components/SelectBar/index.tsx
+++ b/src/pages/joblist/_components/SelectBar/index.tsx
@@ -11,20 +11,34 @@ type SelectBarProps = {
 };
 
 const SelectBar = ({ sort, onSortChange, onApplyFilter }: SelectBarProps) => {
-  const [openFilter, setOpenFilter] = useState(false);
+  const [isOpenFilter, setIsOpenFilter] = useState(false);
+  const [isOpenSelectBox, setIsOpenSelectBox] = useState(false);
 
   const handleFilterToggle = () => {
-    setOpenFilter((prev) => !prev);
+    setIsOpenFilter((prev) => !prev);
+    if (isOpenSelectBox === true) {
+      setIsOpenSelectBox(false);
+    }
+  };
+
+  const handleSelectBoxToggle = () => {
+    setIsOpenSelectBox((prev) => !prev);
+    if (isOpenFilter === true) {
+      setIsOpenFilter(false);
+    }
   };
 
   return (
     <div className="relative flex gap-10">
       <SelectBox
+        isOpen={isOpenSelectBox}
+        setIsOpen={setIsOpenSelectBox}
         options={SORT_OPTIONS}
         placeholder={SORT_OPTIONS.find((option) => option.value === sort)?.label}
         className="min-w-114 border-none bg-gray-10 px-12 py-8 text-14 font-bold"
         dropdownClassname="border-gray-10"
         onChange={onSortChange}
+        onClick={handleSelectBoxToggle}
       />
       <button
         type="button"
@@ -33,10 +47,10 @@ const SelectBar = ({ sort, onSortChange, onApplyFilter }: SelectBarProps) => {
       >
         상세 필터
       </button>
-      {openFilter && (
+      {isOpenFilter && (
         <div className="absolute right--1 top-50 z-50 tablet:right-0">
           <Filter
-            isOpen={openFilter}
+            isOpen={isOpenFilter}
             onClose={handleFilterToggle}
             closeOnEsc={true}
             className={"bg-white"}


### PR DESCRIPTION
## 이슈번호

close #205

## 변경 사항 요약

refactor/SelectBox 열고 닫는 상태 부모로 이전

### 추가된 기능
<img width="226" height="63" alt="스크린샷 2025-10-20 오후 4 07 56" src="https://github.com/user-attachments/assets/e1d8c73d-031d-447b-816b-ad822b52acac" />
이제 버튼을 눌렀을 때 다른 창을 닫고 버튼 누른 창이 열립니다.,

### 스크린샷

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항

```ts
//SelectBox를 사용하는 부모컴포넌트에 상태 만들어주시고
const [isOpenSelectBox, setIsOpenSelectBox] = useState(false);

//호출할 때 상태 넣어주시기만 하면 끝입니다!
<SelectBox
    isOpen={isOpenSelectBox}
    setIsOpen={setIsOpenSelectBox}
        ...
/>

```