### PR TITLE
[#207]design: 페이 배지 수정

### DIFF
--- a/src/components/Badge/PayBadge/index.tsx
+++ b/src/components/Badge/PayBadge/index.tsx
@@ -50,7 +50,7 @@ const PayBadge = ({
         )}
         {...props}
       >
-        <div className={cn(payDifference > 1 ? "visible" : "invisible")}>
+        <div className={cn(payDifference > 0 ? "visible" : "invisible")}>
           <div
             className={cn(
               "absolute h-full w-full rounded-20",

--- a/src/components/Badge/PayBadge/index.tsx
+++ b/src/components/Badge/PayBadge/index.tsx
@@ -41,16 +41,16 @@ const PayBadge = ({
 
   return (
     <>
-      {payDifference > 0 && (
-        <div
-          className={cn(
-            "relative flex max-w-fit items-center text-12-regular leading-none tablet:text-14-bold",
-            post && closed ? "text-gray-10" : "text-red-40 tablet:text-white",
-            !post && !closed && "text-white tablet:text-white",
-            !post && closed && "hidden",
-          )}
-          {...props}
-        >
+      <div
+        className={cn(
+          "relative flex max-w-fit items-center text-12-regular leading-none tablet:text-14-bold",
+          post && closed ? "text-gray-10" : "text-red-40 tablet:text-white",
+          !post && !closed && "text-white tablet:text-white",
+          !post && closed && "hidden",
+        )}
+        {...props}
+      >
+        <div className={cn(payDifference > 1 ? "visible" : "invisible")}>
           <div
             className={cn(
               "absolute h-full w-full rounded-20",
@@ -73,7 +73,7 @@ const PayBadge = ({
             <div className="w-12 tablet:w-14">{icon}</div>
           </div>
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/components/Badge/PayBadge/index.tsx
+++ b/src/components/Badge/PayBadge/index.tsx
@@ -40,37 +40,41 @@ const PayBadge = ({
   };
 
   return (
-    <div
-      className={cn(
-        "relative flex max-w-fit items-center text-12-regular leading-none tablet:text-14-bold",
-        post && closed ? "text-gray-10" : "text-red-40 tablet:text-white",
-        !post && !closed && "text-white tablet:text-white",
-        !post && closed && "hidden",
+    <>
+      {payDifference > 0 && (
+        <div
+          className={cn(
+            "relative flex max-w-fit items-center text-12-regular leading-none tablet:text-14-bold",
+            post && closed ? "text-gray-10" : "text-red-40 tablet:text-white",
+            !post && !closed && "text-white tablet:text-white",
+            !post && closed && "hidden",
+          )}
+          {...props}
+        >
+          <div
+            className={cn(
+              "absolute h-full w-full rounded-20",
+              post && !closed && "hidden tablet:block",
+              post && closed && "hidden tablet:block tablet:bg-gray-20",
+              !post && !closed && "bg-red-40",
+            )}
+            style={{ backgroundColor: closed ? "#e5e4e7" : opacityLevel() }}
+          ></div>
+          <div
+            className={cn(
+              "relative z-10 flex max-w-fit gap-x-4",
+              post ? "px-0 py-0 tablet:px-12 tablet:py-10" : "px-12 py-10",
+              !post && closed && "hidden",
+              post && closed && "text-gray-30 tablet:text-white",
+            )}
+          >
+            <span className={"inline-block"}>{label}</span>
+            <span className="text-12-regular after:content-['%'] tablet:text-14-bold">{payDifference.toFixed(0)}</span>
+            <div className="w-12 tablet:w-14">{icon}</div>
+          </div>
+        </div>
       )}
-      {...props}
-    >
-      <div
-        className={cn(
-          "absolute h-full w-full rounded-20",
-          post && !closed && "bg-white tablet:bg-red-40",
-          post && closed && "bg-white tablet:bg-gray-20",
-          !post && !closed && "bg-red-40",
-        )}
-        style={{ backgroundColor: opacityLevel() }}
-      ></div>
-      <div
-        className={cn(
-          "relative z-10 flex max-w-fit gap-x-4",
-          post ? "px-0 py-0 tablet:px-12 tablet:py-10" : "px-12 py-10",
-          !post && closed && "hidden",
-          post && closed && "tablet:text-white",
-        )}
-      >
-        <span className={"inline-block"}>{label}</span>
-        <span className="text-12-regular after:content-['%'] tablet:text-14-bold">{payDifference.toFixed(0)}</span>
-        <div className="w-12 tablet:w-14">{icon}</div>
-      </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## 이슈번호

close #207

## 변경 사항 요약

- 0% 이하일때 안보이도록 수정, 
- 인라인 스타일로 배경색 받으면서 나온 문제 수정

### 추가된 기능



### 스크린샷
<img width="407" height="550" alt="1" src="https://github.com/user-attachments/assets/c23694bb-0abd-49ca-a16d-70e50e17fb92" />
<img width="844" height="722" alt="2" src="https://github.com/user-attachments/assets/dee44500-c6e7-490c-a463-e7cd973e6842" />

### PR 올리기 전 체크리스트 (필수로 체크)

- [x] 작업한 내용과 커밋 메시지 컨벤션을 통일했는지 확인
- [x] 내가 작성한 코드를 테스트까지 완료했는지 잘 작동했는지 확인

### 리뷰어를 위한 참고 사항


